### PR TITLE
Update CssSelectorHelperWidgetContext.js

### DIFF
--- a/src/CssSelectorHelperWidget/widget/CssSelectorHelperWidgetContext.js
+++ b/src/CssSelectorHelperWidget/widget/CssSelectorHelperWidgetContext.js
@@ -72,8 +72,8 @@
 								}
 							}
 							else {
-								if (this.domNode.previousSibling) {
-									this.domNode.previousSibling.setAttribute('cssSelectorHelper', attributeValue);
+								if (this.domNode.previousElementSibling) {
+									this.domNode.previousElementSibling.setAttribute('cssSelectorHelper', attributeValue);
 								} else {
 									console.warn('CssSelectorHelperWidget: No previous sibling found');
 								}


### PR DESCRIPTION
In Mendix 7 extra html elements are included with <!--  react-mount-point-unstable  !>. Those will prevent the working of previousSibling. Using previousElementSibling will skip text and comment.